### PR TITLE
Add project name pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ pylint = "^2.17.4"
 pylint-quotes = "^0.2.3"
 pdoc = "^14.0.0"
 
+[project]
+name = "tastytrade-sdk"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file. The change adds a `[project]` section with the name "tastytrade-sdk".


fixes the following error when building
```
          raise RuntimeError("The Poetry configuration is invalid:\n" + message)
      RuntimeError: The Poetry configuration is invalid:
        - project must contain ['name'] properties
      
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```